### PR TITLE
Added link to vis.academy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 For what it is capable of, take a look at [kepler.gl demo app](https://uber.github.io/kepler.gl/#/demo).
 
 Kepler.gl is a redux component that uses redux reducer to store and manage state transitions.
-This package consists of a reducer and the UI components to render and customize the map.
+This package consists of a reducer and the UI components to render and customize the map. 
+
+For information on how to save the map state you've created and have it persist after you've closed the browser, take a look at this tutorial on [vis.academy](http://vis.academy/#/kepler.gl/setup).
 
 ## User guide
 Check out [kepler.gl's user documentation here](docs/a-introduction.md)


### PR DESCRIPTION
Added sentence about going to vis.academy http://vis.academy/#/kepler.gl/setup for information on how to embed kepler.gl. This information is useful for people who want to share the map they've made with other people. Not everyone who comes to the readme will know that additional "how to" documentation is at vis.academy unless they're told.